### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,5 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+testresources==5.4.5
 urllib3==1.25.9


### PR DESCRIPTION
Requires an additional package, testresources, that was not in the initial requirements file. Causes error with launchpadlib if this is not installed while doing the pip3 install of requirements.txt.